### PR TITLE
Add email hash id support

### DIFF
--- a/modules/quantcastIdSystem.js
+++ b/modules/quantcastIdSystem.js
@@ -14,6 +14,7 @@ const DEFAULT_COOKIE_EXP_TIME = 392; // (13 months - 2 days)
 const PREBID_PCODE = 'p-KceJUEvXN48CE'; // Not associated with a real account
 const DOMAIN_QSERVE = 'https://pixel.quantserve.com/pixel';
 
+var emailHash;
 var cookieExpTime;
 
 export const storage = getStorageManager();
@@ -41,6 +42,8 @@ export function firePixel() {
     '&d=' + domain +
     '&et=' + et +
     '&tzo=' + tzo +
+    '&uh=' + emailHash +
+    '&uht=1' +
     '&a=' + PREBID_PCODE;
 
     triggerPixel(url);
@@ -73,8 +76,10 @@ export const quantcastIdSubmodule = {
     // Consent signals are currently checked on the server side.
     let fpa = storage.getCookie(QUANTCAST_FPA);
 
+    const configParams = (config && config.params) || {};
     const storageParams = (config && config.storage) || {};
 
+    emailHash = configParams.uh || '';
     cookieExpTime = storageParams.expires || DEFAULT_COOKIE_EXP_TIME;
 
     // Callbacks on Event Listeners won't trigger if the event is already complete so this check is required


### PR DESCRIPTION
<!--
Thank you for your pull request. Please make sure this PR is scoped to one change, and that any added or changed code includes tests with greater than 80% code coverage. See https://github.com/prebid/Prebid.js/blob/master/CONTRIBUTING.md#testing-prebidjs for documentation on testing Prebid.js.
-->

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter  <!--  IMPORTANT: if checking here, also submit your bidder params documentation here https://github.com/prebid/prebid.github.io/tree/master/dev-docs/bidders --> 
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
<!-- Describe the change proposed in this pull request -->
This adds support for Quantcast ID module to use email hash id if provided by user. 

<!-- For new bidder adapters, please provide the following -->
- test parameters for validating bids
```
{
  bidder: '<bidder name>',
  params: {
    uid: "73062D872926C2A556F17B36F50E328DDF9BFF9D403939BD14B6C3B7F5A33FC2",
  }
}
```
